### PR TITLE
Feature: add function to get all device application packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,30 @@ RNAndroidPM.getPackageInfo('/storage/emulated/0/myapp.apk')
         lastUpdateTime: 1283058,
       }
     */
+  });
+
+RNAndroidPM.getInstalledPackages()
+  .then(packages => {
+    console.log(packages);
+    /*
+      [
+        {
+          package: "com.example.myapp",
+          label: "My App",
+          versionName: "1.2.3",
+          versionCode: 3,
+          firstInstallTime: 1185920,
+          lastUpdateTime: 1283058,
+        },
+        {
+          package: "com.example.anotherapp",
+          label: "Another App",
+          versionName: "1.0.0",
+          versionCode: 1,
+          firstInstallTime: 1185920,
+          lastUpdateTime: 1283058,
+        }
+      ]
+    */
   })
 ```

--- a/android/src/main/java/com/reactlibrary/PackageInfoMapping.java
+++ b/android/src/main/java/com/reactlibrary/PackageInfoMapping.java
@@ -14,9 +14,9 @@ public class PackageInfoMapping {
   private ApplicationInfo applicationInfo;
 
   public PackageInfoMapping(PackageInfo packageInfo, PackageManager packageManager) {
-      this.packageInfo = packageInfo;
-      this.packageManager = packageManager;
-      this.applicationInfo = packageInfo.applicationInfo;
+    this.packageInfo = packageInfo;
+    this.packageManager = packageManager;
+    this.applicationInfo = packageInfo.applicationInfo;
   }
 
   public WritableMap asWritableMap() {
@@ -36,12 +36,13 @@ public class PackageInfoMapping {
   }
 
   private String loadPackageLabel() {
-    String label = this.applicationInfo.packageName;
-    try
-    {
-        label = this.applicationInfo.loadLabel(this.packageManager).toString();
+    String label;
+    try {
+      label = this.applicationInfo.loadLabel(this.packageManager).toString();
     }
-    catch (Exception exc) { }
+    catch (Exception exc) {
+      label = this.applicationInfo.packageName;
+    }
     return label;
   }
 }

--- a/android/src/main/java/com/reactlibrary/PackageInfoMapping.java
+++ b/android/src/main/java/com/reactlibrary/PackageInfoMapping.java
@@ -1,0 +1,30 @@
+package com.reactlibrary;
+
+import android.content.pm.PackageInfo;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+
+public class PackageInfoMapping {
+
+  private PackageInfo packageInfo;
+  private String label;
+
+  public PackageInfoMapping(PackageInfo packageInfo, String label) {
+      this.packageInfo = packageInfo;
+      this.label = label;
+  }
+
+  public WritableMap asWritableMap() {
+    WritableMap map = Arguments.createMap();
+
+    map.putString("label", this.label);
+    map.putString("package", this.packageInfo.packageName);
+    map.putString("versionName", this.packageInfo.versionName);
+    map.putDouble("versionCode", this.packageInfo.versionCode);
+    map.putDouble("firstInstallTime", this.packageInfo.firstInstallTime);
+    map.putDouble("lastUpdateTime", this.packageInfo.lastUpdateTime);
+
+    return map;
+  }
+}

--- a/android/src/main/java/com/reactlibrary/PackageInfoMapping.java
+++ b/android/src/main/java/com/reactlibrary/PackageInfoMapping.java
@@ -27,7 +27,7 @@ public class PackageInfoMapping {
 
     map.putString("package", this.packageInfo.packageName);
     map.putString("versionName", this.packageInfo.versionName);
-    map.putDouble("versionCode", this.packageInfo.versionCode);
+    map.putInt("versionCode", this.packageInfo.versionCode);
     map.putDouble("firstInstallTime", this.packageInfo.firstInstallTime);
     map.putDouble("lastUpdateTime", this.packageInfo.lastUpdateTime);
     map.putBoolean("isSystemApp", (this.applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) != 0);

--- a/android/src/main/java/com/reactlibrary/PackageInfoMapping.java
+++ b/android/src/main/java/com/reactlibrary/PackageInfoMapping.java
@@ -1,6 +1,8 @@
 package com.reactlibrary;
 
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
@@ -8,17 +10,21 @@ import com.facebook.react.bridge.WritableMap;
 public class PackageInfoMapping {
 
   private PackageInfo packageInfo;
-  private String label;
+  private PackageManager packageManager;
+  private ApplicationInfo applicationInfo;
 
-  public PackageInfoMapping(PackageInfo packageInfo, String label) {
+  public PackageInfoMapping(PackageInfo packageInfo, PackageManager packageManager) {
       this.packageInfo = packageInfo;
-      this.label = label;
+      this.packageManager = packageManager;
+      this.applicationInfo = packageInfo.applicationInfo;
   }
 
   public WritableMap asWritableMap() {
     WritableMap map = Arguments.createMap();
 
-    map.putString("label", this.label);
+    String label = loadPackageLabel();
+    map.putString("label", label);
+
     map.putString("package", this.packageInfo.packageName);
     map.putString("versionName", this.packageInfo.versionName);
     map.putDouble("versionCode", this.packageInfo.versionCode);
@@ -26,5 +32,15 @@ public class PackageInfoMapping {
     map.putDouble("lastUpdateTime", this.packageInfo.lastUpdateTime);
 
     return map;
+  }
+
+  private String loadPackageLabel() {
+    String label = this.applicationInfo.packageName;
+    try
+    {
+        label = this.applicationInfo.loadLabel(this.packageManager).toString();
+    }
+    catch (Exception exc) { }
+    return label;
   }
 }

--- a/android/src/main/java/com/reactlibrary/RNAndroidPackagemanagerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAndroidPackagemanagerModule.java
@@ -10,7 +10,10 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+
+import java.util.List;
 
 public class RNAndroidPackagemanagerModule extends ReactContextBaseJavaModule {
 
@@ -51,6 +54,49 @@ public class RNAndroidPackagemanagerModule extends ReactContextBaseJavaModule {
       info.putDouble("lastUpdateTime", lastUpdateTime);
 
       promise.resolve(info);
+    }
+    catch (Exception ex) {
+      ex.printStackTrace();
+      promise.reject(null, ex.getMessage());
+    }
+  }
+
+  @ReactMethod
+  public void getInstalledPackages(Promise promise) {
+    try {
+      WritableArray array = Arguments.createArray();
+
+      PackageManager pm = this.reactContext.getPackageManager();
+      List<PackageInfo> packages = pm.getInstalledPackages(0);
+      for (PackageInfo pi : packages)
+      {
+        ApplicationInfo ai = pi.applicationInfo;
+        String label = ai.packageName;
+
+        try
+        {
+            label = ai.loadLabel(pm).toString();
+        }
+        catch (Exception exc) { }
+
+        String pkg = pi.packageName;
+        String versionName = pi.versionName;
+        int versionCode = pi.versionCode;
+        long firstInstallTime = pi.firstInstallTime;
+        long lastUpdateTime = pi.lastUpdateTime;
+
+        WritableMap info = Arguments.createMap();
+        info.putString("package", pkg);
+        info.putString("label", label);
+        info.putString("versionName", versionName);
+        info.putDouble("versionCode", versionCode);
+        info.putDouble("firstInstallTime", firstInstallTime);
+        info.putDouble("lastUpdateTime", lastUpdateTime);
+
+        array.pushMap(info);
+      }
+
+      promise.resolve(array);
     }
     catch (Exception ex) {
       ex.printStackTrace();

--- a/android/src/main/java/com/reactlibrary/RNAndroidPackagemanagerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAndroidPackagemanagerModule.java
@@ -1,7 +1,6 @@
 
 package com.reactlibrary;
 
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 
@@ -34,13 +33,8 @@ public class RNAndroidPackagemanagerModule extends ReactContextBaseJavaModule {
     try {
       PackageManager pm = this.reactContext.getPackageManager();
       PackageInfo pi = pm.getPackageArchiveInfo(path, 0);
-      ApplicationInfo ai = pi.applicationInfo;
-      ai.sourceDir = path;
-      ai.publicSourceDir = path;
 
-      String label = pm.getApplicationLabel(ai).toString();
-
-      PackageInfoMapping info = new PackageInfoMapping(pi, label);
+      PackageInfoMapping info = new PackageInfoMapping(pi, pm);
       WritableMap map = info.asWritableMap();
 
       promise.resolve(map);
@@ -60,16 +54,7 @@ public class RNAndroidPackagemanagerModule extends ReactContextBaseJavaModule {
       List<PackageInfo> packages = pm.getInstalledPackages(0);
       for (PackageInfo pi : packages)
       {
-        ApplicationInfo ai = pi.applicationInfo;
-        String label = ai.packageName;
-
-        try
-        {
-            label = ai.loadLabel(pm).toString();
-        }
-        catch (Exception exc) { }
-
-        PackageInfoMapping info = new PackageInfoMapping(pi, label);
+        PackageInfoMapping info = new PackageInfoMapping(pi, pm);
         WritableMap map = info.asWritableMap();
 
         array.pushMap(map);

--- a/android/src/main/java/com/reactlibrary/RNAndroidPackagemanagerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAndroidPackagemanagerModule.java
@@ -38,22 +38,12 @@ public class RNAndroidPackagemanagerModule extends ReactContextBaseJavaModule {
       ai.sourceDir = path;
       ai.publicSourceDir = path;
 
-      String pkg = pi.packageName;
       String label = pm.getApplicationLabel(ai).toString();
-      String versionName = pi.versionName;
-      int versionCode = pi.versionCode;
-      long firstInstallTime = pi.firstInstallTime;
-      long lastUpdateTime = pi.lastUpdateTime;
 
-      WritableMap info = Arguments.createMap();
-      info.putString("package", pkg);
-      info.putString("label", label);
-      info.putString("versionName", versionName);
-      info.putDouble("versionCode", versionCode);
-      info.putDouble("firstInstallTime", firstInstallTime);
-      info.putDouble("lastUpdateTime", lastUpdateTime);
+      PackageInfoMapping info = new PackageInfoMapping(pi, label);
+      WritableMap map = info.asWritableMap();
 
-      promise.resolve(info);
+      promise.resolve(map);
     }
     catch (Exception ex) {
       ex.printStackTrace();
@@ -79,21 +69,10 @@ public class RNAndroidPackagemanagerModule extends ReactContextBaseJavaModule {
         }
         catch (Exception exc) { }
 
-        String pkg = pi.packageName;
-        String versionName = pi.versionName;
-        int versionCode = pi.versionCode;
-        long firstInstallTime = pi.firstInstallTime;
-        long lastUpdateTime = pi.lastUpdateTime;
+        PackageInfoMapping info = new PackageInfoMapping(pi, label);
+        WritableMap map = info.asWritableMap();
 
-        WritableMap info = Arguments.createMap();
-        info.putString("package", pkg);
-        info.putString("label", label);
-        info.putString("versionName", versionName);
-        info.putDouble("versionCode", versionCode);
-        info.putDouble("firstInstallTime", firstInstallTime);
-        info.putDouble("lastUpdateTime", lastUpdateTime);
-
-        array.pushMap(info);
+        array.pushMap(map);
       }
 
       promise.resolve(array);

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ export interface PackageInfo {
 
 declare class RNAndroidPackagemanager {
   static getPackageInfo(fullPath: string): Promise<PackageInfo>;
+  static getInstalledPackages(): Promise<PackageInfo[]>;
 }
 
 export default RNAndroidPackagemanager;


### PR DESCRIPTION
Add `getInstalledPackages()` function to `RNAndroidPackagemanagerModule` class. The new method will retrieve all the device application installed packages.

Upstream purposed PR: staltz/react-native-android-packagemanager#2