### PR TITLE
Improvement: support options for getInstalledPackages and optional loading package label 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ RNAndroidPM.getPackageInfo('/storage/emulated/0/myapp.apk')
     */
   });
 
-RNAndroidPM.getInstalledPackages()
+RNAndroidPM.getInstalledPackages({})
   .then(packages => {
     console.log(packages);
     /*

--- a/android/src/main/java/com/reactlibrary/PackageInfoMapping.java
+++ b/android/src/main/java/com/reactlibrary/PackageInfoMapping.java
@@ -9,40 +9,67 @@ import com.facebook.react.bridge.WritableMap;
 
 public class PackageInfoMapping {
 
-  private PackageInfo packageInfo;
-  private PackageManager packageManager;
-  private ApplicationInfo applicationInfo;
+  private String packageName;
+  private String label;
+  private String versionName;
+  private int versionCode;
+  private long firstInstallTime;
+  private long lastUpdateTime;
 
-  public PackageInfoMapping(PackageInfo packageInfo, PackageManager packageManager) {
-    this.packageInfo = packageInfo;
-    this.packageManager = packageManager;
-    this.applicationInfo = packageInfo.applicationInfo;
+  private PackageInfoMapping(PackageInfo packageInfo, String label) {
+    this.label = label;
+    this.packageName = packageInfo.packageName;
+    this.versionName = packageInfo.versionName;
+    this.versionCode = packageInfo.versionCode;
+    this.firstInstallTime = packageInfo.firstInstallTime;
+    this.lastUpdateTime = packageInfo.lastUpdateTime;
   }
 
   public WritableMap asWritableMap() {
     WritableMap map = Arguments.createMap();
 
-    String label = loadPackageLabel();
-    map.putString("label", label);
-
-    map.putString("package", this.packageInfo.packageName);
-    map.putString("versionName", this.packageInfo.versionName);
-    map.putInt("versionCode", this.packageInfo.versionCode);
-    map.putDouble("firstInstallTime", this.packageInfo.firstInstallTime);
-    map.putDouble("lastUpdateTime", this.packageInfo.lastUpdateTime);
-    map.putBoolean("isSystemApp", (this.applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) != 0);
+    map.putString("label", this.label);
+    map.putString("package", this.packageName);
+    map.putString("versionName", this.versionName);
+    map.putInt("versionCode", this.versionCode);
+    map.putDouble("firstInstallTime", this.firstInstallTime);
+    map.putDouble("lastUpdateTime", this.lastUpdateTime);
 
     return map;
   }
 
-  private String loadPackageLabel() {
-    String label;
-    try {
-      label = this.applicationInfo.loadLabel(this.packageManager).toString();
+  public static class Builder {
+
+    private boolean loadLabel;
+    private PackageInfo packageInfo;
+    private PackageManager packageManager;
+    private ApplicationInfo applicationInfo;
+
+    public Builder(PackageInfo packageInfo, PackageManager packageManager) {
+      this.packageInfo = packageInfo;
+      this.packageManager = packageManager;
+      this.applicationInfo = packageInfo.applicationInfo;
     }
-    catch (Exception exc) {
-      label = this.applicationInfo.packageName;
+
+    public Builder withLabel(boolean loadLabel) {
+      this.loadLabel = loadLabel;
+      return this;
     }
-    return label;
+
+    public PackageInfoMapping build() {
+      String label = this.loadLabel ? this.loadPackageLabel() : null;
+      return new PackageInfoMapping(this.packageInfo, label);
+    }
+
+    private String loadPackageLabel() {
+      String label;
+      try {
+        label = this.applicationInfo.loadLabel(this.packageManager).toString();
+      }
+      catch (Exception exc) {
+        label = this.applicationInfo.packageName;
+      }
+      return label;
+    }
   }
 }

--- a/android/src/main/java/com/reactlibrary/RNAndroidPackagemanagerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAndroidPackagemanagerModule.java
@@ -1,4 +1,3 @@
-
 package com.reactlibrary;
 
 import android.content.pm.PackageInfo;
@@ -34,7 +33,7 @@ public class RNAndroidPackagemanagerModule extends ReactContextBaseJavaModule {
       PackageManager pm = this.reactContext.getPackageManager();
       PackageInfo pi = pm.getPackageArchiveInfo(path, 0);
 
-      PackageInfoMapping info = new PackageInfoMapping(pi, pm);
+      PackageInfoMapping info = new PackageInfoMapping.Builder(pi, pm).withLabel(true).build();
       WritableMap map = info.asWritableMap();
 
       promise.resolve(map);
@@ -54,7 +53,7 @@ public class RNAndroidPackagemanagerModule extends ReactContextBaseJavaModule {
       List<PackageInfo> packages = pm.getInstalledPackages(0);
       for (PackageInfo pi : packages)
       {
-        PackageInfoMapping info = new PackageInfoMapping(pi, pm);
+        PackageInfoMapping info = new PackageInfoMapping.Builder(pi, pm).withLabel(true).build();
         WritableMap map = info.asWritableMap();
 
         array.pushMap(map);

--- a/android/src/main/java/com/reactlibrary/RNAndroidPackagemanagerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAndroidPackagemanagerModule.java
@@ -8,6 +8,7 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 
@@ -45,15 +46,17 @@ public class RNAndroidPackagemanagerModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void getInstalledPackages(Promise promise) {
+  public void getInstalledPackages(ReadableMap options, Promise promise) {
     try {
       WritableArray array = Arguments.createArray();
+
+      boolean loadLabel = options != null && options.hasKey("loadLabel") ? options.getBoolean("loadLabel") : false;
 
       PackageManager pm = this.reactContext.getPackageManager();
       List<PackageInfo> packages = pm.getInstalledPackages(0);
       for (PackageInfo pi : packages)
       {
-        PackageInfoMapping info = new PackageInfoMapping.Builder(pi, pm).withLabel(true).build();
+        PackageInfoMapping info = new PackageInfoMapping.Builder(pi, pm).withLabel(loadLabel).build();
         WritableMap map = info.asWritableMap();
 
         array.pushMap(map);

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export interface PackageInfo {
 
 declare class RNAndroidPackagemanager {
   static getPackageInfo(fullPath: string): Promise<PackageInfo>;
-  static getInstalledPackages(): Promise<PackageInfo[]>;
+  static getInstalledPackages(options: {loadLabel: boolean}): Promise<PackageInfo[]>;
 }
 
 export default RNAndroidPackagemanager;


### PR DESCRIPTION
Running `ApplicationInfo.loadLabel` takes ~20-75ms (depending on device) for each application, since android loads the application apk (hence it's resources) in order to get the label. 
Therefore, supporting optional loading package label can substantially reduce the time needed for `getInstalledPackages`. 

In addition, it will be easy to add other package options such as application category in the future. 